### PR TITLE
Fix emission coupling and update tests

### DIFF
--- a/ext/EarthSciDataExt.jl
+++ b/ext/EarthSciDataExt.jl
@@ -13,11 +13,17 @@ function EarthSciMLBase.couple2(
         [unit=u"kg/mol", description="Carbon molar mass"],
         nmolpermol=1e9,
         [unit=u"ppb", description="nmol/mol, Conversion factor from mol to nmol"],
-        MW_Air=28.97e-3,
-        [unit=u"kg/mol", description="Molar mass of air"],)
+        R=8.31446261815324,
+        [unit=u"m^3*Pa/mol/K", description="Ideal gas constant"],)
 
-    # Emissions are in units of "kg/kg air/s" and need to be converted to "ppb/s" or "nmol/mol/s".
-    uconv = nmolpermol * MW_Air # Conversion factor with MW factored out.
+    # Emissions are in units of "kg/m3/s" and need to be converted to "ppb/s" or "nmol/mol/s".
+    # To do this we need to convert kg of emissions to nmol of emissions,
+    # and we need to convert m3 of air to mol of air.
+    # nmol_emissions = kg_emissions * gperkg / MW_emission * nmolpermol = kg / kg/mol * nmol/mol = nmol
+    # mol_air = m3_air / R / T * P = m3 / (m3*Pa/mol/K) / K * Pa = mol
+    # So, the overall conversion is:
+    # nmol_emissions / mol_air = (kg_emissions / MW_emission * nmolpermol) / (m3_air / R / T * P)
+    uconv = nmolpermol * R * c.T / c.P # Conversion factor with MW factored out.
     operator_compose(c, e, Dict(c.EC => e.PEC => uconv / MW_C))
 end
 

--- a/test/elemental_carbon_test.jl
+++ b/test/elemental_carbon_test.jl
@@ -11,7 +11,6 @@ using Test
         latrange = deg2rad(40.0f0):deg2rad(2):deg2rad(44.0f0),
         lonrange = deg2rad(-97.0f0):deg2rad(2.5):deg2rad(-92.0f0),
         levrange = 1:1,
-        dtype = Float64
     )
 
     structural_simplify(ElementalCarbon())
@@ -32,5 +31,5 @@ using Test
         "ElementalCarbon₊NEI2016MonthlyEmis_PEC(t) ~ (ElementalCarbon₊T*R*nmolpermol*NEI2016MonthlyEmis₊PEC(t)) / (ElementalCarbon₊P*MW_C)",
         obs
     )
-    @test occursin("ElementalCarbon₊T(t) ~ GEOSFP₊I3₊T", obs)
+    @test occursin("ElementalCarbon₊T(t) ~ GEOSFP₊I3₊T(t)", obs)
 end


### PR DESCRIPTION
## Summary
- Restore gas constant R and T/P conversion in emission coupling (EarthSciData v0.13 still uses kg/m³/s units, not kg/kg/s)
- Remove deprecated `dtype` argument from `DomainInfo` in test
- Fix test expectation string to include `(t)` after `GEOSFP₊I3₊T`

## Test plan
- [x] Run elemental carbon test with the fixes - all 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)